### PR TITLE
Removed redundant new lines in test output

### DIFF
--- a/Divergic.Logging.Xunit.UnitTests/DefaultFormatterTests.cs
+++ b/Divergic.Logging.Xunit.UnitTests/DefaultFormatterTests.cs
@@ -18,6 +18,54 @@
         }
 
         [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("  ", false)]
+        [InlineData("stuff", false)]
+        [InlineData(null, true)]
+        [InlineData("", true)]
+        [InlineData("  ", true)]
+        [InlineData("stuff", true)]
+        public void FormatIncludesNewLineBetweenMessageAndException(string message, bool exceptionExists)
+        {
+            var config = new LoggingConfig();
+            var scopeLevel = 1;
+            var name = Guid.NewGuid().ToString();
+            var logLevel = LogLevel.Information;
+            var eventId = Model.Create<EventId>();
+            Exception? exception = exceptionExists
+                ? new ArgumentNullException(Guid.NewGuid().ToString(), Guid.NewGuid().ToString())
+                : null;
+
+            var sut = new DefaultFormatter(config);
+
+            var actual = sut.Format(scopeLevel, name, logLevel, eventId, message, exception);
+
+            actual.Should().NotStartWith(Environment.NewLine);
+            actual.Should().NotEndWith(Environment.NewLine);
+
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                if (exception != null)
+                {
+                    actual.Should().Be($"   Information [{eventId.Id}]: {exception}");
+                }
+                else
+                {
+                    actual.Should().BeEmpty();
+                }
+            }
+            else if (exception != null)
+            {
+                actual.Should().Be($"   Information [{eventId.Id}]: stuff{Environment.NewLine}   Information [{eventId.Id}]: {exception}");
+            }
+            else
+            {
+                actual.Should().Be($"   Information [{eventId.Id}]: stuff");
+            }
+        }
+
+        [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("  ")]

--- a/Divergic.Logging.Xunit.UnitTests/TestOutputLoggerTests.cs
+++ b/Divergic.Logging.Xunit.UnitTests/TestOutputLoggerTests.cs
@@ -97,7 +97,7 @@
             string Formatter(string logState, Exception? error) => message;
             var name = Guid.NewGuid().ToString();
             var expected = string.Format(CultureInfo.InvariantCulture,
-                "{0}{1} [{2}]: {3}" + Environment.NewLine,
+                "{0}{1} [{2}]: {3}",
                 string.Empty,
                 logLevel,
                 eventId.Id,
@@ -150,7 +150,7 @@
             string Formatter(string logState, Exception? error) => message;
             var name = Guid.NewGuid().ToString();
             var expected = string.Format(CultureInfo.InvariantCulture,
-                "{0}{1} [{2}]: {3}" + Environment.NewLine,
+                "{0}{1} [{2}]: {3}",
                 string.Empty,
                 logLevel,
                 eventId.Id,

--- a/Divergic.Logging.Xunit/DefaultFormatter.cs
+++ b/Divergic.Logging.Xunit/DefaultFormatter.cs
@@ -1,8 +1,8 @@
 ﻿namespace Divergic.Logging.Xunit
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
-    using System.Text;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -32,36 +32,31 @@
             string message,
             Exception? exception)
         {
-            const string format = "{0}{2} [{3}]: {4}";
+            const string Format = "{0}{1} [{2}]: {3}";
             var padding = new string(' ', scopeLevel * _config.ScopePaddingSpaces);
-
-            var builder = new StringBuilder();
+            var parts = new List<string>(2);
 
             if (string.IsNullOrWhiteSpace(message) == false)
             {
-                builder.AppendFormat(CultureInfo.InvariantCulture,
-                    format,
-                    padding,
-                    name,
-                    logLevel,
-                    eventId.Id,
-                    message);
-                builder.AppendLine();
+                var part = string.Format(CultureInfo.InvariantCulture, Format, padding, logLevel, eventId.Id, message);
+
+                parts.Add(part);
             }
 
             if (exception != null)
             {
-                builder.AppendFormat(CultureInfo.InvariantCulture,
-                    format,
+                var part = string.Format(
+                    CultureInfo.InvariantCulture,
+                    Format,
                     padding,
-                    name,
                     logLevel,
                     eventId.Id,
                     exception);
-                builder.AppendLine();
+
+                parts.Add(part);
             }
 
-            return builder.ToString();
+            return string.Join(Environment.NewLine, parts);
         }
     }
 }


### PR DESCRIPTION
The issue was that building the message using `DefaultFormatter` included trailing new lines. This value was then written to the test output via `_output.WriteLine` which adds in the additional whitespace.

If someone wants this whitespace added back in, they can roll their own formatter.